### PR TITLE
Readline depends on stdio.h

### DIFF
--- a/consoline.c
+++ b/consoline.c
@@ -5,14 +5,14 @@
 
 #include "consoline.h"
 
-#include <readline/readline.h>
-#include <readline/history.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <signal.h>
 #include <errno.h>
 #include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 
 static const char* current_prompt = NULL;
 static char current_leave_entered_lines_on_stdout = 1;


### PR DESCRIPTION
Hello !
I had compilation errors. It seems to me that readline depends on `stdio.h`, and moving the includes fixed the errors.

Could you add a license to this project ?

```
gcc -Wall -g main.c consoline.c HistoryDatabase.c RbTree.c -lreadline -o consoline
In file included from /usr/include/readline/readline.h:35:0,
                 from consoline.c:8:
/usr/include/readline/rltypedefs.h:71:28: erreur : unknown type name « FILE »
 typedef int rl_getc_func_t PARAMS((FILE *));
                            ^
/usr/include/readline/readline.h:429:20: erreur : unknown type name « FILE »
 extern int rl_getc PARAMS((FILE *));
                    ^
In file included from consoline.c:8:0:
/usr/include/readline/readline.h:558:8: erreur : unknown type name « FILE »
 extern FILE *rl_instream;
        ^~~~
/usr/include/readline/readline.h:559:8: erreur : unknown type name « FILE »
 extern FILE *rl_outstream;
        ^~~~
/usr/include/readline/readline.h:588:8: erreur : unknown type name « rl_getc_func_t »
 extern rl_getc_func_t *rl_getc_function;
        ^~~~~~~~~~~~~~
/usr/include/readline/readline.h:917:3: erreur : unknown type name « FILE »
   FILE *inf;
   ^~~~
/usr/include/readline/readline.h:918:3: erreur : unknown type name « FILE »
   FILE *outf;
   ^~~~
make: *** [Makefile:6: consoline] Error 1
```